### PR TITLE
fix: breaking change prettyOut

### DIFF
--- a/docs/prettyOut.md
+++ b/docs/prettyOut.md
@@ -1,6 +1,6 @@
 ## Description
 
-A function which overrides `toString` method for object or arrays which are passed as arguments.
+A function which overrides `toString` method for objects or arrays which are passed as arguments.
 This is done to have an ability for faster writing string output with JSON values.
 
 If object has more than 3 keys, and array has length more than 3 - spaces will be added,

--- a/docs/prettyOut.md
+++ b/docs/prettyOut.md
@@ -1,10 +1,14 @@
 ## Description
 
-A function which overrides `toString` method for `Object` and `Array` constructors.
+A function which overrides `toString` method for object or arrays which are passed as arguments.
 This is done to have an ability for faster writing string output with JSON values.
 
 If object has more than 3 keys, and array has length more than 3 - spaces will be added,
 and each `key-value` pair will be printed on the new line.
+
+> **Note**
+>
+> Please, keep in mind, once prettyOut was added to object/array it **could not be undone**.
 
 ## Usage
 
@@ -35,7 +39,7 @@ After `prettyOut()` is called:
 
 ```ts
 // Overrides `toString` method.
-nuti.prettyOut();
+nuti.prettyOut(obj, arr, bigObject);
 
 console.log(
   `An object: ${obj}\nAn array: ${arr}\nAnd a bigObject: ${bigObject}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nuti",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nuti",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuti",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "author": "Andrii Lytovchenko <andr.lyt.dev@gmail.com>",
   "license": "MIT",
   "description": "A collection of commonly used utils for Node.js.",

--- a/src/prettyOut.ts
+++ b/src/prettyOut.ts
@@ -5,26 +5,12 @@
  * @license MIT
  */
 
-import { makeFlag } from './flag';
+export const prettyOut = (...objects: Array<object | unknown[]>): void => {
+  for (const obj of objects) {
+    const length = Array.isArray(obj) ? obj.length : Object.keys(obj).length;
 
-const flag = makeFlag();
-
-export const prettyOut = (): void => {
-  if (flag.done) {
-    return;
+    obj.toString = function () {
+      return JSON.stringify(obj, null, length > 3 ? 2 : undefined);
+    };
   }
-
-  Object.prototype.toString = function () {
-    return JSON.stringify(
-      this,
-      null,
-      Object.keys(this).length > 3 ? 2 : undefined,
-    );
-  };
-
-  Array.prototype.toString = function () {
-    return JSON.stringify(this, null, this.length > 3 ? 2 : undefined);
-  };
-
-  flag.setDone();
 };

--- a/test/prettyOut.spec.ts
+++ b/test/prettyOut.spec.ts
@@ -26,7 +26,7 @@ const bigArrResult = `some pretty big array: [
 
 describe('prettyOut function test', () => {
   it('makes console.log pretty', () => {
-    expect.assertions(4);
+    expect.assertions(5);
     const obj = {
       number: 2,
     };
@@ -40,15 +40,14 @@ describe('prettyOut function test', () => {
     const arr = ['f', 'o', 'o'];
     const bigArr = [...arr, 'b', 'a', 'r'];
 
-    nuti.prettyOut();
+    nuti.prettyOut(obj, bigObj, arr, bigArr);
 
     console.log(`some pretty object: ${obj}`);
     console.log(`some pretty big object: ${bigObj}`);
     console.log(`some pretty array: ${arr}`);
     console.log(`some pretty big array: ${bigArr}`);
 
-    // to cover return, if prettyOut was already called.
-    nuti.prettyOut();
+    console.log(`object without pretty out: ${{ someValue: 'some-value' }}`);
 
     const result = Array.from(logSpy.mock.calls.flat());
 
@@ -56,5 +55,6 @@ describe('prettyOut function test', () => {
     expect(result[1]).toBe(bigObjResult);
     expect(result[2]).toBe(arrResult);
     expect(result[3]).toBe(bigArrResult);
+    expect(result[4]).toBe('object without pretty out: [object Object]');
   });
 });


### PR DESCRIPTION
**Breaking change `prettyOut`**

The reason why it is done - when `prettyOut` is used with different libs it can cause unpredictable behavior and bugs, because it changes `toString()` method **for all object or array prototypes**.

This PR removes this behavior - now only specific objects will have custom `toString()` method.